### PR TITLE
Allow the active logged-in user to write mouse events without root

### DIFF
--- a/72-mouse-jiggler.rules
+++ b/72-mouse-jiggler.rules
@@ -1,0 +1,16 @@
+# Allow the active logged-in user to write mouse events without root.
+#
+# Grants an ACL on mouse event devices to the user of the active local
+# session (via systemd-logind's uaccess), so mouse.sh can run without sudo.
+# Only the currently logged-in seat user gets access, not every account.
+#
+# The 72- prefix matters: it runs after 70-uaccess.rules but before
+# 73-seat-late.rules, which invokes the uaccess builtin that writes the ACL.
+# A higher number (e.g. 99-) adds the tag too late and the ACL is never set.
+#
+# Install:
+#   sudo cp 72-mouse-jiggler.rules /etc/udev/rules.d/
+#   sudo udevadm control --reload-rules
+#   sudo udevadm trigger --subsystem-match=input
+#   # then unplug/replug the mouse, or re-login, so the ACL is applied
+SUBSYSTEM=="input", ENV{ID_INPUT_MOUSE}=="1", TAG+="uaccess"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Simplest keep-presence alternative for Wayland. Just a tiny bash script
 
 ```./mouse.sh```
 
+or if you get `error: could not open device (Permission denied)`:
+
+```sudo ./mouse.sh```
+
 ## Running without root
 
 If you get `error: could not open device (Permission denied)`, it's because
@@ -26,4 +30,4 @@ and run `./mouse.sh` normally.
 ## Requirements
 
 You need [evemu](https://www.freedesktop.org/wiki/Evemu/) to run the script. Install it with your package manager: 
-`sudo apt install evemu-tools` or `sudo dnf install evemu`
+`sudo apt install evemu-tools` or `sudo dnf install evemu` or `sudo pacman -Syu evemu`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,21 @@ Simplest keep-presence alternative for Wayland. Just a tiny bash script
 
 ```./mouse.sh```
 
-Or try it with `sudo` if you got an error "error: could not open device (Permission denied)"
+## Running without root
+
+If you get `error: could not open device (Permission denied)`, it's because
+`/dev/input/event*` devices are owned by `root:input`. Instead of `sudo`,
+install the included udev rule, which grants access to the active logged-in
+user only (via `uaccess`):
+
+```
+sudo cp 72-mouse-jiggler.rules /etc/udev/rules.d/
+sudo udevadm control --reload-rules
+sudo udevadm trigger --subsystem-match=input
+```
+
+Then unplug/replug the mouse (or log out and back in) so the ACL is applied,
+and run `./mouse.sh` normally.
 
 ## Requirements
 


### PR DESCRIPTION
Hi! I have added a udev rule to work around the root requirement if you are interested. I tested this on Fedora but it should work on other distros.